### PR TITLE
Adds support for generateAll method

### DIFF
--- a/examples/tools/API/controllers/NewServiceApiController.cs
+++ b/examples/tools/API/controllers/NewServiceApiController.cs
@@ -1,0 +1,17 @@
+﻿using ServicesApp.Models;
+using System;
+using System.Linq;
+using System.Net;
+using System.Web.Http;
+
+namespace ServicesApp.Controllers
+{
+    public class NewServiceApiController : ApiController
+    {
+        [HttpGet]
+        public string Value()
+        {
+            return "NewService";
+        }
+    }
+}

--- a/examples/tools/generateAll.js
+++ b/examples/tools/generateAll.js
@@ -13,7 +13,7 @@ generateTemplateFiles([
         },
     },
     {
-        option: 'Create create new C# API',
+        option: 'Create new C# API',
         defaultCase: '(upperCase)',
         entry: {
             folderPath: './templates/new-service-cs-api/',

--- a/examples/tools/generateAll.js
+++ b/examples/tools/generateAll.js
@@ -1,0 +1,26 @@
+const {generateTemplateFiles} = require('../../dist/generate-template-files.cjs');
+
+generateTemplateFiles([
+    {
+        option: 'Create new JS class',
+        defaultCase: '(upperCase)',
+        entry: {
+            folderPath: './templates/new-service-js-class/',
+        },
+        stringReplacers: ['{{ServiceName}}'],
+        output: {
+            path: './scripts/',
+        },
+    },
+    {
+        option: 'Create create new C# API',
+        defaultCase: '(upperCase)',
+        entry: {
+            folderPath: './templates/new-service-cs-api/',
+        },
+        stringReplacers: ['{{ServiceName}}'],
+        output: {
+            path: './API/controllers/',
+        },
+    },
+], true);

--- a/examples/tools/scripts/NewService/index.js
+++ b/examples/tools/scripts/NewService/index.js
@@ -1,0 +1,5 @@
+class NewService {
+    init() {
+        console.log('This is the init() function of NewService');
+    }
+}

--- a/examples/tools/templates/new-service-cs-api/{{ServiceName}}ApiController.cs
+++ b/examples/tools/templates/new-service-cs-api/{{ServiceName}}ApiController.cs
@@ -1,0 +1,17 @@
+﻿using ServicesApp.Models;
+using System;
+using System.Linq;
+using System.Net;
+using System.Web.Http;
+
+namespace ServicesApp.Controllers
+{
+    public class {{ServiceName}}ApiController : ApiController
+    {
+        [HttpGet]
+        public string Value()
+        {
+            return "{{ServiceName}}";
+        }
+    }
+}

--- a/examples/tools/templates/new-service-js-class/{{ServiceName}}/index.js
+++ b/examples/tools/templates/new-service-js-class/{{ServiceName}}/index.js
@@ -1,0 +1,5 @@
+class {{ServiceName}} {
+    init() {
+        console.log('This is the init() function of {{ServiceName}}');
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,11 @@ export type IReplacer = IReplacerDefault;
 /**
  * Main method to create your template files. Accepts an array of `IConfigItem` items.
  */
-export function generateTemplateFiles(data: IConfigItem[]): Promise<void> {
-    return new GenerateTemplateFiles().generate(data);
+export function generateTemplateFiles(data: IConfigItem[], shouldGenerateAll: boolean = false): Promise<void> {
+    if (data.length > 0) {
+        return shouldGenerateAll ? new GenerateTemplateFiles().generateAll(data) : new GenerateTemplateFiles().generate(data);
+    }
+
+    console.error('No config items found.');
+    return Promise.reject();
 }


### PR DESCRIPTION
rather than prompting the user to select from the list of template options provided in the config, `generateAll` allows users to process all of the options in one batch.

**example config:**
```javascript
generateTemplateFiles([
    {
        option: 'Create new JS class',
        defaultCase: '(upperCase)',
        entry: {
            folderPath: './templates/new-service-js-class/',
        },
        stringReplacers: ['{{ServiceName}}'],
        output: {
            path: './scripts/',
        },
    },
    {
        option: 'Create new C# API',
        defaultCase: '(upperCase)',
        entry: {
            folderPath: './templates/new-service-cs-api/',
        },
        stringReplacers: ['{{ServiceName}}'],
        output: {
            path: './API/controllers/',
        },
    },
], true);
```
*note the extra argument to the function*

**experience:**

![generate-template-files-demo](https://user-images.githubusercontent.com/11093219/61762418-c2fb9000-ad86-11e9-8e60-8639d4fe3635.gif)

@codeBelt - please let me know if this potential enhancement makes sense to you. my inspiration was wanting to generate files in multiple directories with the same `stringReplacer` value(s), as this was all part of the same boilerplate step~ 🙂 