### PR TITLE
Can use the generator in command line

### DIFF
--- a/src/GenerateTemplateFiles.ts
+++ b/src/GenerateTemplateFiles.ts
@@ -52,10 +52,8 @@ export default class GenerateTemplateFiles {
             name: 'optionChoice',
             message: 'What do you want to generate?',
             choices: options.map((configItem: IConfigItem) => configItem.option),
-            suggest(input: string, choices: string[]) {
-                return choices.filter((choice: any) => {
-                    return choice.message.toLowerCase().startsWith(input.toLowerCase());
-                });
+            suggest(input: string, choices: any[]) {
+                return choices.filter((choice: any) => (choice.message as string).toLowerCase().includes(input.toLowerCase()));
             },
         };
         const templateAnswers: {optionChoice: string} = await enquirer.prompt(templateQuestions);

--- a/src/GenerateTemplateFiles.ts
+++ b/src/GenerateTemplateFiles.ts
@@ -116,15 +116,14 @@ export default class GenerateTemplateFiles {
                 if (option === 'outputpath') {
                     outputPath = value;
                 } else {
-                    const optionUnderscore = '__' + option + '__';
                     if (!selectedConfigItem.stringReplacers?.length) {
                         throw new Error(`Too much arguments`);
                     }
                     const test = selectedConfigItem.stringReplacers.some((item: string | IReplacerSlotQuestion) => {
                         if (typeof item === 'string') {
-                            return item === optionUnderscore;
+                            return item === option;
                         }
-                        return item.slot === optionUnderscore;
+                        return item.slot === option;
                     });
                     if (!test) {
                         throw new Error(`${option} is not a valid string replacer from ${selectedConfigItem.option} config`);
@@ -132,7 +131,7 @@ export default class GenerateTemplateFiles {
                     if (stringReplacers[option]) {
                         throw new Error(`The ${option} string replacer is already defined`);
                     }
-                    stringReplacers[optionUnderscore] = value;
+                    stringReplacers[option] = value;
                 }
             }
         });

--- a/src/enums/EMode.enum.ts
+++ b/src/enums/EMode.enum.ts
@@ -1,0 +1,4 @@
+export enum EMode {
+    prompt,
+    commandLine,
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,5 +19,5 @@ export type IReplacerSlotQuestion = IReplacerSlotQuestionDefault;
  * Main method to create your template files. Accepts an array of `IConfigItem` items.
  */
 export function generateTemplateFiles(data: IConfigItem[]): Promise<void> {
-    return new GenerateTemplateFiles().generate(data);
+    return new GenerateTemplateFiles().generate(data, process.argv.slice(2));
 }

--- a/src/models/IConfigItem.ts
+++ b/src/models/IConfigItem.ts
@@ -32,6 +32,14 @@ export default interface IConfigItem {
      */
     option: string;
     /**
+     * The option name's alias. You should use this alias with the command line mode.
+     *
+     * ```
+     * option: 'mycommand',
+     * ```
+     */
+    alias: string;
+    /**
      * The default [Case Converters](#case-converters) to use with the [Replacer Slots](#replacer-slots) in the template files or path/file name. Default is `(noCase)`.
      *
      * ```

--- a/src/models/IMainParams.ts
+++ b/src/models/IMainParams.ts
@@ -1,0 +1,11 @@
+import IReplacer from './IReplacer';
+import IConfigItem from './IConfigItem';
+
+export default interface IMainParams {
+    selectedConfigItem: IConfigItem;
+    answeredReplacers: IReplacer[];
+    contentReplacers: IReplacer[];
+    outputPathReplacers: IReplacer[];
+    outputPath: string;
+    forceWrite?: boolean;
+}


### PR DESCRIPTION
We can now use the generator by this way:
`node generate.js  name-of-templates  string-replacer1=some-name  string-replacer2=some-other-name  outputpath=/just/here  --force`

I tried to code in the same way as what had been done but you should review it.
I didn't update the readme because my english is not perfect and I think you will change many pieces of code.