### PR TITLE
Add validation for stringReplacers when using command line. Improvements

### DIFF
--- a/src/GenerateTemplateFiles.ts
+++ b/src/GenerateTemplateFiles.ts
@@ -91,9 +91,7 @@ export default class GenerateTemplateFiles {
         const contentReplacers: IReplacer[] = this._getReplacers(replacers, contentCase);
         const outputPathReplacers: IReplacer[] = this._getReplacers(replacers, outputPathCase);
         const outputPath: string = await this._getOutputPath(outputPathReplacers, selectedConfigItem);
-        const shouldWriteFiles: boolean = GenerateTemplateFiles.isCommandLine
-            ? yargs.argv.overwrite === true
-            : await this._shouldWriteFiles(outputPath);
+        const shouldWriteFiles: boolean = await this._shouldWriteFiles(outputPath);
 
         if (shouldWriteFiles === false) {
             console.info('No new files created');
@@ -243,6 +241,10 @@ export default class GenerateTemplateFiles {
 
         if (doesPathExist === false) {
             return true;
+        }
+
+        if (GenerateTemplateFiles.isCommandLine) {
+            return yargs.argv.overwrite === true;
         }
 
         const overwriteFilesAnswer: any = await enquirer.prompt({

--- a/src/GenerateTemplateFiles.ts
+++ b/src/GenerateTemplateFiles.ts
@@ -54,22 +54,22 @@ export default class GenerateTemplateFiles {
                 return StringUtility.isString(item) ? item : item.slot;
             });
 
-            CheckUtility.check(
-                (stringReplacersSlotNames?.length ?? 0) === slots.length,
-                `The number of arguments do not match the number of stringReplacers for ${templateName}`
-            );
-
-            const commandLineReplacers: IReplacer[] = slots.map((str: string) => {
-                const [slot, slotValue] = str.split('=');
+            const commandLineReplacersObject: {[slot: string]: string} = slots.reduce((accumulator, argument: string) => {
+                const [slot, slotValue] = argument.split('=');
+                accumulator[slot] = slotValue;
 
                 const isValidReplacer = Boolean(stringReplacersSlotNames?.includes(slot));
                 CheckUtility.check(isValidReplacer, `${slot} is not found in stringReplacers for ${templateName}`);
 
-                return {
-                    slot,
-                    slotValue,
-                };
-            });
+                return accumulator;
+            }, {});
+
+            const commandLineReplacers: IReplacer[] = Object.entries(commandLineReplacersObject).map(([slot, slotValue]) => ({slot, slotValue}));
+
+            CheckUtility.check(
+                (stringReplacersSlotNames?.length ?? 0) === commandLineReplacers.length,
+                `The number of arguments does not match the number of stringReplacers for ${templateName}`
+            );
             const dynamicReplacers: IReplacer[] = selectedConfigItem.dynamicReplacers || [];
 
             await this._outputFiles(selectedConfigItem, [...commandLineReplacers, ...dynamicReplacers]);

--- a/src/GenerateTemplateFiles.ts
+++ b/src/GenerateTemplateFiles.ts
@@ -50,7 +50,7 @@ export default class GenerateTemplateFiles {
         });
 
         CheckUtility.check(
-            stringReplacersSlotNames?.length === slots.length,
+            (stringReplacersSlotNames?.length ?? 0) === slots.length,
             `The number of arguments do not match the number of stringReplacers for ${templateName}`
         );
 

--- a/src/utilities/CheckUtility.ts
+++ b/src/utilities/CheckUtility.ts
@@ -9,7 +9,7 @@ export default class CheckUtility {
      */
     public static check(predicate: boolean, errorMessage: string): void {
         if (CheckUtility._isNotTypeBoolean(predicate) === true) {
-            throw CheckUtility.check(false, `CheckUtility.check()'s first argument must be a boolean but argument was of type ${typeof predicate}`);
+            CheckUtility.check(false, `CheckUtility.check()'s first argument must be a boolean but argument was of type ${typeof predicate}`);
         } else if (predicate === true) {
             return;
         }


### PR DESCRIPTION
You can see commit by commit what I did.
The main bug was when stringReplacers was not defined. slots length was equals to 0 and stringReplacers to undefined. Therefore the test `stringReplacers?.length === slots.length` was false.

I added too try/catch blocks to catch the errors and display them. I don't think it's really "elegant" but we must do that I guess.

An other "bug" could happen when you define two times the same stringReplacer as argument.
Example : 
`node generate.js vue-vuex-store __store__=firstValue __model__=myModel __store__=secondValue`
Here, our code will throw an error because the length of arguments is not equal to the length of stringReplacers.
We could imagine that we take the last value passed as argument for each stringReplacer.
Therefore in this case, there would be no problems.
I don't know what behavior you want for this case.