### PR TITLE
Non-interactive mode

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 4
+indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Example
 Here is the string `Lives down BY the River` with each of the converters:
 
 ```js
-// If you typed in 'Lives down BY the River' for the a Replacer Slot named '__replacerSlot__' and 
+// If you typed in 'Lives down BY the River' for the a Replacer Slot named '__replacerSlot__' and
 // used one of the optional Case Converters you would get the following:
 
 __replacerSlot__(noCase)        // Lives down BY the River
@@ -224,7 +224,7 @@ __replacerSlot__(sentenceCase)  // Lives down by the river
 __replacerSlot__(snakeCase)     // lives_down_by_the_river
 __replacerSlot__(titleCase)     // Lives Down By The River
 
-// Note: you can set a 'defaultCase' converter in IConfigItem so all 
+// Note: you can set a 'defaultCase' converter in IConfigItem so all
 // Replacer Slots without a Case Converter will be transformed the same way.
 __replacerSlot__                // LivesDownByTheRiver
 ```
@@ -233,6 +233,52 @@ One Rule: no spaces between the [Replacer Slots](#replacer-slots-or-ireplacerslo
 
 - :white_check_mark: `__name__(camelCase)`
 - :warning: `__name__ (camelCase)`
+
+## Batch Usage
+
+You can use `generate-template-files` to generate your template files programmatically, without any interactive prompts. This mode does not support `stringReplacers`.
+
+The following example will generate the component, unit tests, and the SCSS module in one do.
+
+```ts
+// generateTemplateFile.ts
+import { generateTemplateFilesCommandLine, CaseConverterEnum } from 'generate-template-files');
+
+export const componentWithInterface = async (componentName: string, componentScope: string = "common"): Promise<void> => {
+  await generateTemplateFilesBatch([
+    {
+      option: 'Component',
+      defaultCase: CaseConverterEnum.PascalCase,
+      entry: {
+        folderPath: './tools/templates/react/component',
+      },
+      dynamicReplacers: [
+        { slot: '__name__', slotValue: componentName },
+        { slot: '__scope__', slotValue: componentScope },
+      ],
+      output: {
+        path: `./src/component/__scope__(camelCase)`,
+        pathAndFileNameDefaultCase: CaseConverterEnum.PascalCase,
+      },
+    },
+    {
+      option: 'Component Interface',
+      defaultCase: CaseConverterEnum.PascalCase,
+      entry: {
+        folderPath: './tools/templates/react/I__interface__.ts',
+      },
+      dynamicReplacers: [
+        { slot: '__interface__', slotValue: componentName },
+        { slot: '__scope__', slotValue: componentScope },
+      ],
+      output: {
+        path: `./src/component/__scope__(camelCase)/I__interface__.ts`,
+        pathAndFileNameDefaultCase: CaseConverterEnum.PascalCase,
+      },
+    },
+  ]);
+};
+```
 
 ## Command Line Usage
 

--- a/README.md
+++ b/README.md
@@ -212,21 +212,21 @@ Here is the string `Lives down BY the River` with each of the converters:
 // If you typed in 'Lives down BY the River' for the a Replacer Slot named '__replacerSlot__' and
 // used one of the optional Case Converters you would get the following:
 
-__replacerSlot__(noCase)        // Lives down BY the River
-__replacerSlot__(camelCase)     // livesDownByTheRiver
-__replacerSlot__(constantCase)  // LIVES_DOWN_BY_THE_RIVER
-__replacerSlot__(dotCase)       // lives.down.by.the.river
-__replacerSlot__(kebabCase)     // lives-down-by-the-river
-__replacerSlot__(lowerCase)     // livesdownbytheriver
-__replacerSlot__(pascalCase)    // LivesDownByTheRiver
-__replacerSlot__(pathCase)      // lives/down/by/the/river
-__replacerSlot__(sentenceCase)  // Lives down by the river
-__replacerSlot__(snakeCase)     // lives_down_by_the_river
-__replacerSlot__(titleCase)     // Lives Down By The River
+__replacerSlot__(noCase); //        Lives down BY the River
+__replacerSlot__(camelCase); //     livesDownByTheRiver
+__replacerSlot__(constantCase); //  LIVES_DOWN_BY_THE_RIVER
+__replacerSlot__(dotCase); //       lives.down.by.the.river
+__replacerSlot__(kebabCase); //     lives-down-by-the-river
+__replacerSlot__(lowerCase); //     livesdownbytheriver
+__replacerSlot__(pascalCase); //    LivesDownByTheRiver
+__replacerSlot__(pathCase); //      lives/down/by/the/river
+__replacerSlot__(sentenceCase); //  Lives down by the river
+__replacerSlot__(snakeCase); //     lives_down_by_the_river
+__replacerSlot__(titleCase); //     Lives Down By The River
 
 // Note: you can set a 'defaultCase' converter in IConfigItem so all
 // Replacer Slots without a Case Converter will be transformed the same way.
-__replacerSlot__                // LivesDownByTheRiver
+__replacerSlot__; //                LivesDownByTheRiver
 ```
 
 One Rule: no spaces between the [Replacer Slots](#replacer-slots-or-ireplacerslotquestion) and [Case Converters](#case-converters). If there is a space, [Case Converters](#case-converters) will not work.
@@ -240,15 +240,15 @@ You can use `generate-template-files` to generate your template files programmat
 
 The following example will generate the component, unit tests, and the SCSS module in one do.
 
-```ts
-// generateTemplateFile.ts
-import { generateTemplateFilesCommandLine, CaseConverterEnum } from 'generate-template-files');
+```js
+// generateTemplateFile.js
+const { generateTemplateFilesBatch } = require('generate-template-files');
 
-export const componentWithInterface = async (componentName: string, componentScope: string = "common"): Promise<void> => {
-  await generateTemplateFilesBatch([
+const componentWithInterface = (componentName, componentScope = 'common') => {
+  generateTemplateFilesBatch([
     {
       option: 'Component',
-      defaultCase: CaseConverterEnum.PascalCase,
+      defaultCase: '(pascalCase)',
       entry: {
         folderPath: './tools/templates/react/component',
       },
@@ -258,12 +258,12 @@ export const componentWithInterface = async (componentName: string, componentSco
       ],
       output: {
         path: `./src/component/__scope__(camelCase)`,
-        pathAndFileNameDefaultCase: CaseConverterEnum.PascalCase,
+        pathAndFileNameDefaultCase: '(pascalCase)',
       },
     },
     {
       option: 'Component Interface',
-      defaultCase: CaseConverterEnum.PascalCase,
+      defaultCase: '(pascalCase)',
       entry: {
         folderPath: './tools/templates/react/I__interface__.ts',
       },
@@ -273,10 +273,12 @@ export const componentWithInterface = async (componentName: string, componentSco
       ],
       output: {
         path: `./src/component/__scope__(camelCase)/I__interface__.ts`,
-        pathAndFileNameDefaultCase: CaseConverterEnum.PascalCase,
+        pathAndFileNameDefaultCase: '(pascalCase)',
       },
     },
-  ]);
+  ]).catch(() => {
+    console.log('Build Error');
+  });
 };
 ```
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "---------- Normal Example -------------------------------------------": "",
     "generate": "node ./tools/generate.js",
+    "batchGenerate": "node ./tools/batchGenerate.js",
     "---------- Command Line Example -------------------------------------": "",
     "commandlineSimple": "node ./tools/commandLine.js angular-ngrx-store __name__=some-name __model__=some-other-name",
     "commandline": "node ./tools/commandLine.js angular-ngrx-store __name__=some-name __model__=some-other-name --outputpath=./src/here --overwrite"

--- a/examples/tools/batchGenerate.js
+++ b/examples/tools/batchGenerate.js
@@ -1,0 +1,41 @@
+// generateTemplateFile.js
+const {generateTemplateFilesBatch, CaseConverterEnum} = require('../../dist/generate-template-files.cjs');
+// Note: In your file it will be like this:
+// const {generateTemplateFilesBatch} = require('generate-template-files');
+
+const componentName = "Example"
+const componentScope = "common"
+
+generateTemplateFilesBatch([
+  {
+    option: 'Component',
+    defaultCase: CaseConverterEnum.PascalCase,
+    entry: {
+      folderPath: './tools/templates/react/component',
+    },
+    dynamicReplacers: [
+      { slot: '__name__', slotValue: componentName },
+      { slot: '__scope__', slotValue: componentScope },
+    ],
+    output: {
+      path: `./src/component/__scope__(camelCase)`,
+      pathAndFileNameDefaultCase: CaseConverterEnum.PascalCase,
+    },
+  },
+  {
+    option: 'Component Interface',
+    defaultCase: CaseConverterEnum.PascalCase,
+    entry: {
+      folderPath: './tools/templates/react/I__interface__.ts',
+    },
+    dynamicReplacers: [
+      { slot: '__interface__', slotValue: componentName },
+      { slot: '__scope__', slotValue: componentScope },
+    ],
+    output: {
+      path: `./src/component/__scope__(camelCase)/I__interface__.ts`,
+      pathAndFileNameDefaultCase: CaseConverterEnum.PascalCase,
+    },
+  },
+]);
+

--- a/examples/tools/batchGenerate.js
+++ b/examples/tools/batchGenerate.js
@@ -1,7 +1,7 @@
 // generateTemplateFile.js
 const {generateTemplateFilesBatch, CaseConverterEnum} = require('../../dist/generate-template-files.cjs');
 // Note: In your file it will be like this:
-// const {generateTemplateFilesBatch} = require('generate-template-files');
+// const {generateTemplateFilesBatch, CaseConverterEnum} = require('generate-template-files');
 
 const componentName = "Example"
 const componentScope = "common"

--- a/src/GenerateTemplateFiles.ts
+++ b/src/GenerateTemplateFiles.ts
@@ -96,18 +96,14 @@ export default class GenerateTemplateFiles {
   public async batchGenerate(options: Omit<IConfigItem, 'stringReplacers'>[]) {
     this._isBatch = true;
 
-    try {
-      throwErrorIfNoConfigItems(options);
-      throwErrorIfStringReplacersExistOrNoDynamicReplacers(options);
+    throwErrorIfNoConfigItems(options);
+    throwErrorIfStringReplacersExistOrNoDynamicReplacers(options);
 
-      for (const selectedConfigItem of options) {
-        const answeredReplacers: IReplacer[] = await this._getDynamicReplacerSlotValues(
-          selectedConfigItem
-        );
-        await this._outputFiles(selectedConfigItem, answeredReplacers);
-      }
-    } catch (error) {
-      displayError(error.message);
+    for (const selectedConfigItem of options) {
+      const answeredReplacers: IReplacer[] = await this._getDynamicReplacerSlotValues(
+        selectedConfigItem
+      );
+      await this._outputFiles(selectedConfigItem, answeredReplacers);
     }
   }
 

--- a/src/GenerateTemplateFiles.ts
+++ b/src/GenerateTemplateFiles.ts
@@ -1,4 +1,4 @@
-import * as enquirer from 'enquirer';
+import enquirer from 'enquirer';
 import recursiveCopy from 'recursive-copy';
 import pathExists from 'path-exists';
 import through from 'through2';
@@ -11,9 +11,10 @@ import IResults from './models/IResults';
 import IDefaultCaseConverter from './models/IDefaultCaseConverter';
 import {
   throwErrorIfNoConfigItems,
-  throwErrorIfOptionNameIsNotFound,
   throwErrorIfNoStringOrDynamicReplacers,
+  throwErrorIfOptionNameIsNotFound,
   throwErrorIfStringReplacersDoNotMatch,
+  throwErrorIfStringReplacersExistOrNoDynamicReplacers,
   displayError,
   displayWarning,
   displaySuccess,
@@ -23,6 +24,7 @@ import yargs from 'yargs';
 
 export default class GenerateTemplateFiles {
   private _isCommandLine: boolean = false;
+  private _isBatch: boolean = false;
 
   /**
    * Main method to create your template files. Accepts an array of `IConfigItem` items.
@@ -83,6 +85,27 @@ export default class GenerateTemplateFiles {
         ...commandLineStringReplacers,
         ...dynamicReplacers,
       ]);
+    } catch (error) {
+      displayError(error.message);
+    }
+  }
+
+  /**
+   * Main method to run generate on multiple templates at once, without any interactive prompts
+   */
+  public async batchGenerate(options: Omit<IConfigItem, 'stringReplacers'>[]) {
+    this._isBatch = true;
+
+    try {
+      throwErrorIfNoConfigItems(options);
+      throwErrorIfStringReplacersExistOrNoDynamicReplacers(options);
+
+      for (const selectedConfigItem of options) {
+        const answeredReplacers: IReplacer[] = await this._getDynamicReplacerSlotValues(
+          selectedConfigItem
+        );
+        await this._outputFiles(selectedConfigItem, answeredReplacers);
+      }
     } catch (error) {
       displayError(error.message);
     }
@@ -184,9 +207,20 @@ export default class GenerateTemplateFiles {
         };
       }
     );
-    const dynamicReplacers: IReplacer[] = selectedConfigItem.dynamicReplacers || [];
+    const dynamicReplacers = await this._getDynamicReplacerSlotValues(selectedConfigItem);
 
     return [...replacers, ...dynamicReplacers];
+  }
+
+  /**
+   * Dynamic replacer values, used for interactive and batch generation
+   */
+  private async _getDynamicReplacerSlotValues(
+    selectedConfigItem: IConfigItem
+  ): Promise<IReplacer[]> {
+    const dynamicReplacers: IReplacer[] = selectedConfigItem.dynamicReplacers || [];
+
+    return dynamicReplacers;
   }
 
   /**
@@ -239,6 +273,10 @@ export default class GenerateTemplateFiles {
       return outputPath ?? outputPathFormatted;
     }
 
+    if (this._isBatch) {
+      return outputPathFormatted;
+    }
+
     const outputPathAnswer: any = await enquirer.prompt({
       type: 'input',
       name: 'outputPath',
@@ -267,6 +305,10 @@ export default class GenerateTemplateFiles {
 
     if (this._isCommandLine) {
       return selectedConfigItem.output.overwrite || yargs.argv.overwrite === true;
+    }
+
+    if (this._isBatch) {
+      return Boolean(selectedConfigItem.output.overwrite);
     }
 
     const overwriteFilesAnswer: any = await enquirer.prompt({

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,3 +28,12 @@ export function generateTemplateFiles(data: IConfigItem[]): Promise<void> {
 export function generateTemplateFilesCommandLine(data: IConfigItem[]): Promise<void> {
   return new GenerateTemplateFiles().commandLine(data);
 }
+
+/**
+ * Main method to run generate on multiple templates at once, without any interactive prompts.
+ */
+export function generateTemplateFilesBatch(
+  data: Omit<IConfigItem, 'stringReplacers'>[]
+): Promise<void> {
+  return new GenerateTemplateFiles().batchGenerate(data);
+}

--- a/src/utilities/CheckUtility.ts
+++ b/src/utilities/CheckUtility.ts
@@ -72,3 +72,16 @@ export const throwErrorIfNoStringOrDynamicReplacers = (options: IConfigItem[]) =
     throw new Error('IConfigItem needs to have a stringReplacers or dynamicReplacers.');
   }
 };
+
+export const throwErrorIfStringReplacersExistOrNoDynamicReplacers = (options: IConfigItem[]) => {
+  const allValidBatchEntries =
+    options.every((item: IConfigItem) => {
+      return !Boolean(item?.stringReplacers?.length) && Boolean(item?.dynamicReplacers?.length);
+    }) && options.length > 0;
+
+  if (!allValidBatchEntries) {
+    throw new Error(
+      'IConfigItem for batchGenerate does not support stringReplacers, and must have dynamicReplacers.'
+    );
+  }
+};

--- a/src/utilities/GenerateTemplateFiles.batch.test.ts
+++ b/src/utilities/GenerateTemplateFiles.batch.test.ts
@@ -2,7 +2,7 @@ import GenerateTemplateFiles from '../GenerateTemplateFiles';
 import { IConfigItem } from '../index';
 import CaseConverterEnum from '../constants/CaseConverterEnum';
 
-describe.skip('GenerateTemplateFiles - Batch', () => {
+describe('GenerateTemplateFiles - Batch', () => {
   test('should throw an error if no IConfigItem items', () => {
     const items: IConfigItem[] = [];
     const gtf = new GenerateTemplateFiles();
@@ -12,7 +12,7 @@ describe.skip('GenerateTemplateFiles - Batch', () => {
     );
   });
 
-  test('should throw an error if no stringReplacers or dynamicReplacers', () => {
+  test('should throw an error if no stringReplacers or dynamicReplacers', async () => {
     const items: IConfigItem[] = [
       {
         option: 'some-template',
@@ -27,12 +27,12 @@ describe.skip('GenerateTemplateFiles - Batch', () => {
     ];
     const gtf = new GenerateTemplateFiles();
 
-    expect(() => gtf.commandLine(items)).rejects.toThrowError(
-      'IConfigItem needs to have a stringReplacers or dynamicReplacers.'
+    await expect(() => gtf.batchGenerate(items)).rejects.toThrowError(
+      'IConfigItem for batchGenerate does not support stringReplacers, and must have dynamicReplacers'
     );
   });
 
-  test('should throw an error if batch IConfigItem is not found for option name', () => {
+  test('should throw an error if batch IConfigItem is not found for option name', async () => {
     const items: IConfigItem[] = [
       {
         option: 'some-template',
@@ -48,7 +48,7 @@ describe.skip('GenerateTemplateFiles - Batch', () => {
     ];
     const gtf = new GenerateTemplateFiles();
 
-    expect(() => gtf.batchGenerate(items)).rejects.toThrowError(
+    await expect(() => gtf.batchGenerate(items)).rejects.toThrowError(
       `IConfigItem for batchGenerate does not support stringReplacers, and must have dynamicReplacers.`
     );
   });

--- a/src/utilities/GenerateTemplateFiles.batch.test.ts
+++ b/src/utilities/GenerateTemplateFiles.batch.test.ts
@@ -1,0 +1,55 @@
+import GenerateTemplateFiles from '../GenerateTemplateFiles';
+import { IConfigItem } from '../index';
+import CaseConverterEnum from '../constants/CaseConverterEnum';
+
+describe.skip('GenerateTemplateFiles - Batch', () => {
+  test('should throw an error if no IConfigItem items', () => {
+    const items: IConfigItem[] = [];
+    const gtf = new GenerateTemplateFiles();
+
+    expect(() => gtf.batchGenerate(items)).rejects.toThrowError(
+      'There was no IConfigItem items found.'
+    );
+  });
+
+  test('should throw an error if no stringReplacers or dynamicReplacers', () => {
+    const items: IConfigItem[] = [
+      {
+        option: 'some-template',
+        defaultCase: CaseConverterEnum.PascalCase,
+        entry: {
+          folderPath: 'path',
+        },
+        output: {
+          path: 'path',
+        },
+      },
+    ];
+    const gtf = new GenerateTemplateFiles();
+
+    expect(() => gtf.commandLine(items)).rejects.toThrowError(
+      'IConfigItem needs to have a stringReplacers or dynamicReplacers.'
+    );
+  });
+
+  test('should throw an error if batch IConfigItem is not found for option name', () => {
+    const items: IConfigItem[] = [
+      {
+        option: 'some-template',
+        defaultCase: CaseConverterEnum.PascalCase,
+        stringReplacers: ['__name__'],
+        entry: {
+          folderPath: 'path',
+        },
+        output: {
+          path: 'path',
+        },
+      },
+    ];
+    const gtf = new GenerateTemplateFiles();
+
+    expect(() => gtf.batchGenerate(items)).rejects.toThrowError(
+      `IConfigItem for batchGenerate does not support stringReplacers, and must have dynamicReplacers.`
+    );
+  });
+});

--- a/src/utilities/GenerateTemplateFiles.commandline.test.ts
+++ b/src/utilities/GenerateTemplateFiles.commandline.test.ts
@@ -2,14 +2,27 @@ import GenerateTemplateFiles from '../GenerateTemplateFiles';
 import { IConfigItem } from '../index';
 import CaseConverterEnum from '../constants/CaseConverterEnum';
 import yargs from 'yargs';
+import colors from 'colors';
 
-describe.skip('GenerateTemplateFiles - Command Line', () => {
+let consoleInfoSpy: jest.SpyInstance;
+describe('GenerateTemplateFiles - Command Line', () => {
+  beforeEach(() => {
+    consoleInfoSpy = jest.spyOn(global.console, 'info').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    consoleInfoSpy.mockRestore();
+  });
+
   test('should throw an error if no IConfigItem items', () => {
     const items: IConfigItem[] = [];
     const gtf = new GenerateTemplateFiles();
 
-    expect(() => gtf.commandLine(items)).rejects.toThrowError(
-      'There was no IConfigItem items found.'
+    gtf.commandLine(items);
+    expect(consoleInfoSpy).toBeCalledWith(
+      colors.bold.red(
+        `[Error in generate-template-files]: ${colors.red('There was no IConfigItem items found.')}`
+      )
     );
   });
 
@@ -33,8 +46,13 @@ describe.skip('GenerateTemplateFiles - Command Line', () => {
     ];
     const gtf = new GenerateTemplateFiles();
 
-    expect(() => gtf.commandLine(items)).rejects.toThrowError(
-      `No IConfigItem found for ${notFoundOptionName}`
+    gtf.commandLine(items);
+    expect(consoleInfoSpy).toBeCalledWith(
+      colors.bold.red(
+        `[Error in generate-template-files]: ${colors.red(
+          `No IConfigItem found for ${notFoundOptionName}`
+        )}`
+      )
     );
   });
 
@@ -53,8 +71,13 @@ describe.skip('GenerateTemplateFiles - Command Line', () => {
     ];
     const gtf = new GenerateTemplateFiles();
 
-    expect(() => gtf.commandLine(items)).rejects.toThrowError(
-      'IConfigItem needs to have a stringReplacers or dynamicReplacers.'
+    gtf.commandLine(items);
+    expect(consoleInfoSpy).toBeCalledWith(
+      colors.bold.red(
+        `[Error in generate-template-files]: ${colors.red(
+          'IConfigItem needs to have a stringReplacers or dynamicReplacers.'
+        )}`
+      )
     );
   });
 });


### PR DESCRIPTION
This PR introduces a batch mode to the generator, which can be used to programmatically create a bunch of files in one go. This can be extremely useful when bootstrapping a system since such an operation often requires creating a lot of files from a list. This approach is also much easier to integrate with an IDE, opening up the potential for an extension that hooks into the generator.

Closes #47 