### PR TITLE
adding custom string replacer for flex replace

### DIFF
--- a/examples/tools/items.js
+++ b/examples/tools/items.js
@@ -33,6 +33,21 @@ const items = [
             folderPath: './tools/templates/vue/vuex-store/',
         },
         stringReplacers: ['__store__', '__model__'],
+        dynamicReplacers: [
+            {
+                slot:"__store1__custom__",
+                newSlot:({__store__})=>{
+                    return `${__store__} from other string replacer`
+                }
+            },
+            {
+                slot:"__store2_from_other_custom1",
+                newSlot:({__store1__custom__})=>{
+                    return __store1__custom__+ " and custom dynamic replacer"
+                }
+            }
+
+    ],
         output: {
             path: './src/stores/__store__(kebabCase)',
             pathAndFileNameDefaultCase: '(pascalCase)',
@@ -50,6 +65,7 @@ const items = [
             folderPath: './tools/templates/react/redux-store/',
         },
         stringReplacers: ['__store__', '__model__'],
+        
         output: {
             path: './src/stores/__store__(kebabCase)',
             pathAndFileNameDefaultCase: '(pascalCase)',
@@ -77,6 +93,7 @@ const items = [
         entry: {
             folderPath: './tools/templates/react/connected-component/',
         },
+
         stringReplacers: ['__name__'],
         output: {
             path: './src/views/__name__(kebabCase)',

--- a/src/models/IObject.ts
+++ b/src/models/IObject.ts
@@ -1,0 +1,3 @@
+export default interface IObjectParamReplacer {
+  [key: string]: string;
+}

--- a/src/models/IReplacer.ts
+++ b/src/models/IReplacer.ts
@@ -1,4 +1,8 @@
+import IObjectParamReplacer from './IObject';
+
 export default interface IReplacer {
   readonly slot: string;
   readonly slotValue: string;
+
+  readonly newSlot?: (params: IObjectParamReplacer) => string;
 }

--- a/src/models/IReplacerSlotQuestion.ts
+++ b/src/models/IReplacerSlotQuestion.ts
@@ -1,4 +1,5 @@
 export default interface IReplacerSlotQuestion {
   readonly question: string;
   readonly slot: string;
+  readonly result?: (value: string) => string;
 }


### PR DESCRIPTION
The first, thank you for creating this library, it's very good for me and community. But when using, sometimes i want to use value of rest `stringReplace` to create another `stringReplace` , so here is my pull request details.
1. add callback function `result` into object of array `stringReplacers` for custom dynamic valueSlot
2. add callback fuction `newSlot` into  object of array `dynamicReplacers` for get and custom rest replacer
Please check pull request and accept it